### PR TITLE
feat: Scalar API 문서 GitHub Pages 배포 워크플로 추가

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -1,0 +1,71 @@
+name: Deploy API Docs
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 매일 03:00 KST (18:00 UTC) 스펙 재동기화
+    - cron: '0 18 * * *'
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-api-docs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 배포는 항상 최신 실행 하나만 유지
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build Site
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp docs/index.html docs/apis.json dist/
+
+          # CORS 때문에 브라우저가 API 서버를 직접 호출할 수 없어 빌드 시점에 스냅샷을 받는다
+          jq -c '.[]' docs/apis.json | while read -r api; do
+            file=$(echo "$api" | jq -r '.file')
+            url=$(echo "$api" | jq -r '.url')
+            echo "Fetching $url -> dist/$file"
+            curl --fail --silent --show-error --location "$url" -o "dist/$file"
+          done
+
+      - name: Validate OpenAPI Documents
+        run: |
+          set -euo pipefail
+          jq -r '.[].file' docs/apis.json | while read -r file; do
+            npx --yes @scalar/cli document validate "dist/$file"
+          done
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/apis.json
+++ b/docs/apis.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Product API",
+    "slug": "product",
+    "file": "openapi.product.json",
+    "url": "https://api.development.bottle-note.com/api/v1/openapi.product.json"
+  },
+  {
+    "title": "Admin API",
+    "slug": "admin",
+    "file": "openapi.admin.json",
+    "url": "https://api.development.bottle-note.com/api/v1/openapi.product.json"
+  }
+]

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <title>보틀노트 API 문서</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <!-- 버전 고정: CDN latest가 깨지면 문서 전체가 죽으므로 명시적으로 올린다 -->
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.64.0"></script>
+
+    <script>
+      // apis.json은 워크플로가 스펙을 내려받을 때도 쓰는 단일 목록이다
+      fetch('./apis.json')
+        .then((res) => res.json())
+        .then((apis) => {
+          Scalar.createApiReference('#app', {
+            sources: apis.map((api, index) => ({
+              title: api.title,
+              slug: api.slug,
+              url: './' + api.file,
+              default: index === 0,
+            })),
+          })
+        })
+        .catch((error) => {
+          document.getElementById('app').textContent =
+            'API 문서 목록을 불러오지 못했습니다: ' + error.message
+        })
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 개요

OpenAPI 문서를 Scalar API Reference로 렌더링해 GitHub Pages에 무료 배포합니다.
배포 주소: https://bottle-note.github.io/workspace/

## 변경 사항

- `docs/apis.json` — API 목록 단일 소스 (title/slug/file/url)
- `docs/index.html` — Scalar 스탠드얼론, CDN `@scalar/api-reference@1.64.0` 버전 고정
- `.github/workflows/deploy-api-docs.yml` — 스펙 다운로드 → 검증 → Pages 배포

## 설계 메모

- API 서버가 외부 Origin 요청을 403으로 막고 있어(CORS) 브라우저가 스펙 URL을 직접 호출할 수 없습니다. 워크플로가 빌드 시점에 스냅샷을 받아 정적 파일로 함께 배포합니다.
- Admin API는 아직 엔드포인트가 없어 임시로 Product 문서를 가리킵니다. `docs/apis.json`의 `url`만 교체하면 됩니다.
- 트리거: 수동(workflow_dispatch) + 매일 03:00 KST cron + `docs/**` 변경 시 push

## 검증

- 스펙 다운로드 2건 성공 (각 311,857 bytes)
- `@scalar/cli document validate` → `Matches the OpenAPI specification (OpenAPI 3.1)`
- 로컬 렌더링 확인: 사이드바 정상, Product ↔ Admin 문서 전환 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)