### PR TITLE
docs: Admin OpenAPI 문서 URL 수정

### DIFF
--- a/docs/apis.json
+++ b/docs/apis.json
@@ -9,6 +9,6 @@
     "title": "Admin API",
     "slug": "admin",
     "file": "openapi.admin.json",
-    "url": "https://api.development.bottle-note.com/api/v1/openapi.product.json"
+    "url": "https://admin-api.development.bottle-note.com/admin/api/v1/openapi.admin.json"
   }
 ]


### PR DESCRIPTION
## 변경 사항

- `docs/apis.json`의 Admin API URL을 배포된 Admin springdoc OpenAPI 경로로 교체했습니다.
- Product API URL은 기존 경로를 유지합니다.

## 배경

API 서버 이슈 #366의 2차 작업 완료 후 workspace Pages가 Admin OpenAPI JSON을 직접 수집하도록 하는 별도 후속 변경입니다.

## 검증

- `jq`로 Product/Admin 항목과 URL 매핑 검증
- `git diff --check` 통과
- Product OpenAPI URL: HTTP 200, `application/json`
- Admin OpenAPI URL: HTTP 200, `application/json`

Closes bottle-note/workspace#366
