### PR TITLE
feat: Admin MCP 게이트웨이(mcp) 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,19 @@
 /.idea/workspace.iml
 
 *.env
+.env
+.env.*
+!.env.example
 /.idea/
+
+# mcp local runtime / secrets (defense in depth)
+mcp/node_modules/
+mcp/dist/
+mcp/git.environment-variables/
+mcp/**/*.sops.yaml
+mcp/**/*.sops.env
+mcp/**/kubeconfig*
+**/*credentials*
+**/*secret*
+*.log
+.DS_Store

--- a/mcp/.dockerignore
+++ b/mcp/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+git.environment-variables
+.env
+.env.*
+*.md
+.DS_Store
+coverage

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -2,10 +2,15 @@
 PORT=3100
 MCP_PATH=/mcp
 LOG_LEVEL=info
+# production | development — production forbids BOTTLENOTE_AGENT_KEY
+NODE_ENV=development
 
-# Admin backend (internal network in k8s; local points to admin-api)
+# Admin backend (in-cluster URL in k8s)
 ADMIN_API_BASE_URL=http://localhost:8080/admin/api/v1
 ADMIN_API_TIMEOUT_MS=15000
 
-# Optional: default agent key only for local smoke (prefer client Authorization header)
-# BOTTLENOTE_AGENT_KEY=bn_agent_...
+# Truncate long whisky description in tool results
+MAX_DESCRIPTION_CHARS=800
+
+# Local smoke ONLY (never set in production)
+# BOTTLENOTE_AGENT_KEY=bn_agent_REPLACE

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -1,0 +1,11 @@
+# MCP gateway
+PORT=3100
+MCP_PATH=/mcp
+LOG_LEVEL=info
+
+# Admin backend (internal network in k8s; local points to admin-api)
+ADMIN_API_BASE_URL=http://localhost:8080/admin/api/v1
+ADMIN_API_TIMEOUT_MS=15000
+
+# Optional: default agent key only for local smoke (prefer client Authorization header)
+# BOTTLENOTE_AGENT_KEY=bn_agent_...

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,27 @@
+# dependencies
+node_modules/
+
+# build
+dist/
+*.tsbuildinfo
+coverage/
+.turbo/
+
+# secrets / local env (never commit)
+.env
+.env.*
+!.env.example
+
+# private config submodule / secrets (if checked out locally)
+git.environment-variables/
+**/*.sops.yaml
+**/*.sops.env
+**/kubeconfig*
+**/*credentials*
+**/*secret*
+
+# logs / OS / IDE
+*.log
+.DS_Store
+.idea/
+.vscode/

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,34 @@
+# Multi-arch (linux/amd64, linux/arm64) Node 22 image.
+# Build: docker buildx build --platform linux/amd64,linux/arm64 -t bottlenote-mcp:local .
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm install --omit=dev
+
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci || npm install
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3100
+ENV TZ=Asia/Seoul
+
+RUN apk add --no-cache tini \
+  && addgroup -S app && adduser -S app -G app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+
+USER app
+EXPOSE 3100
+
+# tini for correct signal handling under k8s
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "dist/index.js"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -11,9 +11,12 @@ Admin / Agent client (Claude, Codex, Cursor)
         |  internal HTTP only (allowlisted paths)
         |  Agent Key -> Admin JWT exchange (JWT never returned to client)
         v
- bottlenote-admin-api  MCP-optimized APIs
-   /admin/api/v1/mcp/...
+ bottlenote-admin-api  (existing APIs only)
+   POST /admin/api/v1/auth/agent
+   GET  /admin/api/v1/alcohols
+   GET  /admin/api/v1/alcohols/{id}
 ```
+
 
 ## Prerequisites
 
@@ -49,12 +52,14 @@ npm run dev
 
 ## Tools (v0.1)
 
-| Tool | Backend |
+| Tool | Backend (existing Admin API) |
 |------|---------|
-| `bottlenote_whisky_search` | `GET /admin/api/v1/mcp/whiskies` |
-| `bottlenote_whisky_get` | `GET /admin/api/v1/mcp/whiskies/{id}` |
+| `bottlenote_whisky_search` | `GET /admin/api/v1/alcohols` |
+| `bottlenote_whisky_get` | `GET /admin/api/v1/alcohols/{id}` |
 
+No dedicated backend `/mcp/*` endpoints. MCP maps/reduces fields for agents.
 Never exposed: delete, bulk, free-form proxy, token minting tools.
+
 
 ## Docker (multi-arch)
 
@@ -79,7 +84,7 @@ docker run --rm -p 3100:3100 \
 1. Clients send **Agent Key only** (never Admin JWT).
 2. Gateway exchanges key via `POST /admin/api/v1/auth/agent` and keeps JWT in memory for the request.
 3. Logs redact `bn_agent_*` and JWTs.
-4. Outbound paths allowlisted (`/auth/agent`, `/mcp/*` only).
+4. Outbound paths allowlisted (`/auth/agent`, `/alcohols`, `/alcohols/{id}` only).
 
 ## Related
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,34 +8,37 @@ Admin / Agent client (Claude, Codex, Cursor)
         |  Authorization: Bearer bn_agent_*
         v
  mcp  (this directory)
-        |  internal HTTP only (allowlisted paths)
-        |  Agent Key -> Admin JWT exchange (JWT never returned to client)
+        |  allowlisted HTTP only
+        |  Agent Key → Admin JWT (never returned)
         v
- bottlenote-admin-api  (existing APIs only)
-   POST /admin/api/v1/auth/agent
-   GET  /admin/api/v1/alcohols
-   GET  /admin/api/v1/alcohols/{id}
+ bottlenote-admin-api (existing APIs)
+   POST /auth/agent
+   GET  /alcohols
+   GET  /alcohols/{id}
 ```
 
+규범·페르소나 교차 검토: [`docs/PRINCIPLES.md`](./docs/PRINCIPLES.md)
 
 ## Prerequisites
 
 - Node.js 22+
-- Private env/config lives in `bottle-note/environment-variables` (not vendored here). Do not commit keys.
+- Secrets: private `environment-variables` / k8s Secret only. Never commit keys.
 
 ## Local run
 
 ```bash
 cp .env.example .env
-# set ADMIN_API_BASE_URL; optional BOTTLENOTE_AGENT_KEY for local smoke only
+# ADMIN_API_BASE_URL required for real calls
+# BOTTLENOTE_AGENT_KEY: local smoke only (forbidden when NODE_ENV=production)
 npm install
 npm run dev
 ```
 
-- Health: `GET http://localhost:3100/healthz`
-- MCP: `POST http://localhost:3100/mcp` with `Authorization: Bearer bn_agent_...`
+- Health: `GET /healthz`
+- Ready: `GET /readyz`
+- MCP: `POST /mcp` with `Authorization: Bearer bn_agent_...`
 
-### Client snippet (Claude / Codex)
+### Client snippet
 
 ```json
 {
@@ -52,42 +55,28 @@ npm run dev
 
 ## Tools (v0.1)
 
-| Tool | Backend (existing Admin API) |
+| Tool | Backend |
 |------|---------|
-| `bottlenote_whisky_search` | `GET /admin/api/v1/alcohols` |
-| `bottlenote_whisky_get` | `GET /admin/api/v1/alcohols/{id}` |
+| `bottlenote_whisky_search` | `GET /alcohols` |
+| `bottlenote_whisky_get` | `GET /alcohols/{id}` |
 
-No dedicated backend `/mcp/*` endpoints. MCP maps/reduces fields for agents.
-Never exposed: delete, bulk, free-form proxy, token minting tools.
+Failures return MCP `isError: true` (no stack/token leakage).
 
+## Security (must)
+
+1. Client credential = **Agent Key only** (JWT-shaped Bearer → 401).
+2. Admin JWT stays in-process after `/auth/agent` exchange.
+3. Logs redact `bn_agent_*` / JWT.
+4. Outbound allowlist: method + path (see `src/policy/allowlist.ts`).
+5. `BOTTLENOTE_AGENT_KEY` **rejected in production**.
 
 ## Docker (multi-arch)
 
 ```bash
-docker buildx build \
-  --platform linux/amd64,linux/arm64 \
-  -t ghcr.io/bottle-note/mcp:0.1.0 \
-  --push .
+docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/bottle-note/mcp:0.1.0 --push .
 ```
-
-Local:
-
-```bash
-docker build -t mcp:local .
-docker run --rm -p 3100:3100 \
-  -e ADMIN_API_BASE_URL=http://host.docker.internal:8080/admin/api/v1 \
-  mcp:local
-```
-
-## Security
-
-1. Clients send **Agent Key only** (never Admin JWT).
-2. Gateway exchanges key via `POST /admin/api/v1/auth/agent` and keeps JWT in memory for the request.
-3. Logs redact `bn_agent_*` and JWTs.
-4. Outbound paths allowlisted (`/auth/agent`, `/alcohols`, `/alcohols/{id}` only).
 
 ## Related
 
 - bottle-note/workspace#370
-- Agent Key exchange: #340
-- Audit actor model: #341
+- #340 Agent Key · #341 audit (future)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,88 @@
+# mcp
+
+Bottle Note **Admin MCP gateway**. Isolated process: no domain DB access.
+
+```
+Admin / Agent client (Claude, Codex, Cursor)
+        |  Streamable HTTP  /mcp
+        |  Authorization: Bearer bn_agent_*
+        v
+ mcp  (this directory)
+        |  internal HTTP only (allowlisted paths)
+        |  Agent Key -> Admin JWT exchange (JWT never returned to client)
+        v
+ bottlenote-admin-api  MCP-optimized APIs
+   /admin/api/v1/mcp/...
+```
+
+## Prerequisites
+
+- Node.js 22+
+- Private env/config lives in `bottle-note/environment-variables` (not vendored here). Do not commit keys.
+
+## Local run
+
+```bash
+cp .env.example .env
+# set ADMIN_API_BASE_URL; optional BOTTLENOTE_AGENT_KEY for local smoke only
+npm install
+npm run dev
+```
+
+- Health: `GET http://localhost:3100/healthz`
+- MCP: `POST http://localhost:3100/mcp` with `Authorization: Bearer bn_agent_...`
+
+### Client snippet (Claude / Codex)
+
+```json
+{
+  "mcpServers": {
+    "bottlenote-admin": {
+      "url": "https://mcp.bottlenote.com/mcp",
+      "headers": {
+        "Authorization": "Bearer bn_agent_REPLACE"
+      }
+    }
+  }
+}
+```
+
+## Tools (v0.1)
+
+| Tool | Backend |
+|------|---------|
+| `bottlenote_whisky_search` | `GET /admin/api/v1/mcp/whiskies` |
+| `bottlenote_whisky_get` | `GET /admin/api/v1/mcp/whiskies/{id}` |
+
+Never exposed: delete, bulk, free-form proxy, token minting tools.
+
+## Docker (multi-arch)
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/bottle-note/mcp:0.1.0 \
+  --push .
+```
+
+Local:
+
+```bash
+docker build -t mcp:local .
+docker run --rm -p 3100:3100 \
+  -e ADMIN_API_BASE_URL=http://host.docker.internal:8080/admin/api/v1 \
+  mcp:local
+```
+
+## Security
+
+1. Clients send **Agent Key only** (never Admin JWT).
+2. Gateway exchanges key via `POST /admin/api/v1/auth/agent` and keeps JWT in memory for the request.
+3. Logs redact `bn_agent_*` and JWTs.
+4. Outbound paths allowlisted (`/auth/agent`, `/mcp/*` only).
+
+## Related
+
+- bottle-note/workspace#370
+- Agent Key exchange: #340
+- Audit actor model: #341

--- a/mcp/docs/PRINCIPLES.md
+++ b/mcp/docs/PRINCIPLES.md
@@ -1,0 +1,51 @@
+# MCP 철학 · 권고 · 지침 (페르소나 교차 검토)
+
+이 문서는 별도 페르소나 5개의 권고를 합쳐 **이 게이트웨이의 규범**으로 고정한다.  
+구현은 이 규범을 어기지 않아야 한다.
+
+## 페르소나 요약
+
+| ID | 페르소나 | 핵심 철학 |
+|----|----------|-----------|
+| P1 | MCP Protocol Engineer | 서버는 **stateless Streamable HTTP**. 클라이언트 세션 점착 금지. 도구 스키마·annotation 명확. |
+| P2 | Security Engineer | **Token passthrough 금지**. 클라이언트는 Agent Key만. Admin JWT는 프로세스 내부. 시크릿 로그 0. |
+| P3 | Platform / SRE | multi-arch, multi-pod, graceful shutdown, correlation id, 작은 blast radius. |
+| P4 | Agent Tool Designer | 도구는 **좁고 읽기 쉬운 계약**. size 상한, 실패는 `isError`, NEVER 목록 명시. |
+| P5 | Isolation Architect | MCP는 도메인 DB 모름. **기존 Admin API allowlist**만 호출. 전용 백엔드 강제 없음. |
+
+## 준수 체크 (workspace `mcp/` v0.1 → 보강 후)
+
+| 규범 | 이전 | 보강 |
+|------|------|------|
+| Stateless transport | OK | 유지 |
+| Agent Key only / no JWT return | 부분 | JWT 형태 Bearer 거부, prod에서 default key 금지 |
+| Outbound allowlist | OK | method+path 이중 검사 |
+| 시크릿 스크럽 | OK | 유지 |
+| Tool error as `isError` | 미흡 | 핸들러 try/catch + isError |
+| Description 컨텍스트 폭증 | 미흡 | 상세 description truncate |
+| Server instructions | 없음 | MCP `instructions` 주입 |
+| Correlation | 부분 | Admin 호출에 `x-correlation-id` 전파 |
+| Graceful shutdown | 없음 | SIGTERM/SIGINT |
+| NEVER 문서화 | README 일부 | PRINCIPLES + instructions |
+
+## NEVER (서버·문서·툴 모두)
+
+- 위스키/엔티티 삭제, bulk 수정, 무페이징 list
+- Admin JWT 클라이언트 수신·반환·로그
+- free-form HTTP 프록시 툴
+- 외부 웹검색·출처 판정 툴
+- 프로덕션 기본 Agent Key env 의존
+
+## 허용 아웃바운드 (v0.1)
+
+| Method | Path |
+|--------|------|
+| POST | `/auth/agent` |
+| GET | `/alcohols` |
+| GET | `/alcohols/{id}` |
+
+## 운영 원칙
+
+1. 키·JWT는 env/Secret에만. 레포·로그·툴 결과에 금지.
+2. 쓰기 툴 추가 시 **서버 `confirm=true` 강제** (annotation은 힌트일 뿐).
+3. Admin UI 계약 변경에 취약하면 매핑 레이어에서 흡수 (전용 API는 선택).

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1826 @@
+{
+  "name": "mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "express": "^5.1.0",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/express": "^5.0.3",
+        "@types/node": "^22.17.0",
+        "tsx": "^4.20.3",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mcp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Bottle Note Admin MCP gateway (isolated). Clients <-> MCP <-> Admin API.",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "express": "^5.1.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3",
+    "@types/node": "^22.17.0",
+    "tsx": "^4.20.3",
+    "typescript": "^5.9.2"
+  }
+}

--- a/mcp/src/auth/agentKey.ts
+++ b/mcp/src/auth/agentKey.ts
@@ -1,4 +1,10 @@
 const AGENT_KEY_PREFIX = "bn_agent_";
+const JWT_LIKE = /^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
+
+export type AgentKeyRejection =
+  | "missing"
+  | "jwt_not_allowed"
+  | "invalid_format";
 
 export function extractAgentKey(
   authorizationHeader: string | undefined,
@@ -13,9 +19,30 @@ export function extractAgentKey(
   return fallback;
 }
 
-export function assertAgentKeyShape(agentKey: string): void {
+/**
+ * Validate client credential for this gateway.
+ * - Reject JWT-shaped tokens (token passthrough / wrong audience).
+ * - Accept only bn_agent_* shape.
+ */
+export function validateAgentKey(
+  agentKey: string | undefined,
+): { ok: true; key: string } | { ok: false; reason: AgentKeyRejection } {
+  if (!agentKey) {
+    return { ok: false, reason: "missing" };
+  }
+  if (JWT_LIKE.test(agentKey)) {
+    return { ok: false, reason: "jwt_not_allowed" };
+  }
   if (!agentKey.startsWith(AGENT_KEY_PREFIX) || agentKey.length < 20) {
-    throw new Error("Invalid agent key format");
+    return { ok: false, reason: "invalid_format" };
+  }
+  return { ok: true, key: agentKey };
+}
+
+export function assertAgentKeyShape(agentKey: string): void {
+  const result = validateAgentKey(agentKey);
+  if (!result.ok) {
+    throw new Error(`Invalid agent key: ${result.reason}`);
   }
 }
 
@@ -25,4 +52,15 @@ export function agentKeyFingerprint(agentKey: string): string {
     return "****";
   }
   return `…${agentKey.slice(-4)}`;
+}
+
+export function rejectionMessage(reason: AgentKeyRejection): string {
+  switch (reason) {
+    case "missing":
+      return "Missing Agent Key (Authorization: Bearer bn_agent_*)";
+    case "jwt_not_allowed":
+      return "Admin/user JWT is not accepted. Use Agent Key (bn_agent_*) only.";
+    case "invalid_format":
+      return "Invalid Agent Key format. Expected bn_agent_*";
+  }
 }

--- a/mcp/src/auth/agentKey.ts
+++ b/mcp/src/auth/agentKey.ts
@@ -1,0 +1,28 @@
+const AGENT_KEY_PREFIX = "bn_agent_";
+
+export function extractAgentKey(
+  authorizationHeader: string | undefined,
+  fallback?: string,
+): string | undefined {
+  if (authorizationHeader) {
+    const match = authorizationHeader.match(/^Bearer\s+(.+)$/i);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+  return fallback;
+}
+
+export function assertAgentKeyShape(agentKey: string): void {
+  if (!agentKey.startsWith(AGENT_KEY_PREFIX) || agentKey.length < 20) {
+    throw new Error("Invalid agent key format");
+  }
+}
+
+export function agentKeyFingerprint(agentKey: string): string {
+  // Never log raw key; last 4 chars only for support correlation.
+  if (agentKey.length < 8) {
+    return "****";
+  }
+  return `…${agentKey.slice(-4)}`;
+}

--- a/mcp/src/backend/adminClient.ts
+++ b/mcp/src/backend/adminClient.ts
@@ -11,7 +11,38 @@ type GlobalResponseEnvelope<T> = {
   success?: boolean;
   data?: T;
   errors?: unknown;
-  meta?: unknown;
+  meta?: Record<string, unknown>;
+};
+
+/** Existing Admin alcohol list item fields (subset). */
+type AdminAlcoholItem = {
+  alcoholId: number;
+  korName?: string | null;
+  engName?: string | null;
+  korCategoryName?: string | null;
+  engCategoryName?: string | null;
+  imageUrl?: string | null;
+};
+
+type AdminAlcoholDetail = {
+  alcoholId: number;
+  korName?: string | null;
+  engName?: string | null;
+  korCategory?: string | null;
+  engCategory?: string | null;
+  imageUrl?: string | null;
+  abv?: string | null;
+  age?: string | null;
+  cask?: string | null;
+  volume?: string | null;
+  description?: string | null;
+  regionId?: number | null;
+  korRegion?: string | null;
+  engRegion?: string | null;
+  distilleryId?: number | null;
+  korDistillery?: string | null;
+  engDistillery?: string | null;
+  tastingTags?: Array<{ id: number; korName?: string | null; engName?: string | null }>;
 };
 
 export type McpWhiskySummary = {
@@ -47,8 +78,8 @@ export type McpWhiskySearchResult = {
 };
 
 /**
- * Outbound client: MCP process -> Admin backend only.
- * Allowlist is enforced by calling fixed path builders (no free-form URL proxy).
+ * Outbound client: MCP process -> existing Admin API only.
+ * No dedicated /mcp/* backend endpoints.
  */
 export class AdminBackendClient {
   constructor(private readonly config: AppConfig) {}
@@ -72,35 +103,80 @@ export class AdminBackendClient {
     accessToken: string,
     params: { keyword?: string; page?: number; size?: number; regionId?: number },
   ): Promise<McpWhiskySearchResult> {
+    const page = params.page ?? 0;
+    const size = Math.min(params.size ?? 20, 50);
     const query = new URLSearchParams();
     if (params.keyword) query.set("keyword", params.keyword);
     if (params.regionId != null) query.set("regionId", String(params.regionId));
-    query.set("page", String(params.page ?? 0));
-    query.set("size", String(Math.min(params.size ?? 20, 50)));
+    query.set("page", String(page));
+    query.set("size", String(size));
 
-    const body = await this.requestJson<GlobalResponseEnvelope<McpWhiskySearchResult>>(
+    // Existing Admin UI contract: GET /alcohols (fromPage → data list + meta)
+    const body = await this.requestJson<GlobalResponseEnvelope<AdminAlcoholItem[]>>(
       "GET",
-      `/mcp/whiskies?${query.toString()}`,
+      `/alcohols?${query.toString()}`,
       undefined,
       accessToken,
     );
-    if (!body.data) {
-      throw new Error("MCP whisky search returned empty data");
-    }
-    return body.data;
+
+    const rows = Array.isArray(body.data) ? body.data : [];
+    const meta = body.meta ?? {};
+    const totalElements =
+      typeof meta.totalElements === "number" ? meta.totalElements : null;
+    const hasNext =
+      typeof meta.hasNext === "boolean" ? meta.hasNext : null;
+
+    return {
+      items: rows.map((row) => ({
+        alcoholId: row.alcoholId,
+        korName: row.korName ?? null,
+        engName: row.engName ?? null,
+        korCategory: row.korCategoryName ?? null,
+        engCategory: row.engCategoryName ?? null,
+        imageUrl: row.imageUrl ?? null,
+      })),
+      page,
+      size,
+      totalElements,
+      hasNext,
+    };
   }
 
   async getWhisky(accessToken: string, alcoholId: number): Promise<McpWhiskyDetail> {
-    const body = await this.requestJson<GlobalResponseEnvelope<McpWhiskyDetail>>(
+    const body = await this.requestJson<GlobalResponseEnvelope<AdminAlcoholDetail>>(
       "GET",
-      `/mcp/whiskies/${alcoholId}`,
+      `/alcohols/${alcoholId}`,
       undefined,
       accessToken,
     );
-    if (!body.data) {
-      throw new Error("MCP whisky detail returned empty data");
+    const d = body.data;
+    if (!d) {
+      throw new Error("Whisky detail returned empty data");
     }
-    return body.data;
+    return {
+      alcoholId: d.alcoholId,
+      korName: d.korName ?? null,
+      engName: d.engName ?? null,
+      korCategory: d.korCategory ?? null,
+      engCategory: d.engCategory ?? null,
+      imageUrl: d.imageUrl ?? null,
+      abv: d.abv ?? null,
+      age: d.age ?? null,
+      cask: d.cask ?? null,
+      volume: d.volume ?? null,
+      description: d.description ?? null,
+      regionId: d.regionId ?? null,
+      korRegion: d.korRegion ?? null,
+      engRegion: d.engRegion ?? null,
+      distilleryId: d.distilleryId ?? null,
+      korDistillery: d.korDistillery ?? null,
+      engDistillery: d.engDistillery ?? null,
+      tastingTags: (d.tastingTags ?? []).map((t) => ({
+        id: t.id,
+        korName: t.korName ?? null,
+        engName: t.engName ?? null,
+      })),
+    };
   }
 
   private async requestJson<T>(
@@ -109,9 +185,14 @@ export class AdminBackendClient {
     jsonBody: unknown | undefined,
     accessToken: string | undefined,
   ): Promise<T> {
-    // Path must stay under fixed allowlist prefixes.
-    if (!path.startsWith("/auth/agent") && !path.startsWith("/mcp/")) {
-      throw new Error(`Outbound path not allowlisted: ${path}`);
+    // Allowlist: agent login + existing alcohol read APIs only.
+    const pathOnly = path.split("?")[0] ?? path;
+    const allowed =
+      pathOnly === "/auth/agent" ||
+      pathOnly === "/alcohols" ||
+      /^\/alcohols\/\d+$/.test(pathOnly);
+    if (!allowed) {
+      throw new Error(`Outbound path not allowlisted: ${pathOnly}`);
     }
 
     const url = `${this.config.adminApiBaseUrl}${path}`;
@@ -140,14 +221,14 @@ export class AdminBackendClient {
       const durationMs = Date.now() - started;
       logInfo("admin_backend_call", {
         method,
-        path: path.split("?")[0],
+        path: pathOnly,
         status: response.status,
         durationMs,
       });
 
       if (!response.ok) {
         throw new Error(
-          `Admin API ${method} ${path.split("?")[0]} failed: ${response.status} ${redactSecrets(text)}`,
+          `Admin API ${method} ${pathOnly} failed: ${response.status} ${redactSecrets(text)}`,
         );
       }
       if (!text) {

--- a/mcp/src/backend/adminClient.ts
+++ b/mcp/src/backend/adminClient.ts
@@ -1,0 +1,164 @@
+import type { AppConfig } from "../config.js";
+import { assertAgentKeyShape } from "../auth/agentKey.js";
+import { logError, logInfo, redactSecrets } from "../logging/redact.js";
+
+export type TokenItem = {
+  accessToken: string;
+  refreshToken?: string;
+};
+
+type GlobalResponseEnvelope<T> = {
+  success?: boolean;
+  data?: T;
+  errors?: unknown;
+  meta?: unknown;
+};
+
+export type McpWhiskySummary = {
+  alcoholId: number;
+  korName: string | null;
+  engName: string | null;
+  korCategory: string | null;
+  engCategory: string | null;
+  imageUrl: string | null;
+};
+
+export type McpWhiskyDetail = McpWhiskySummary & {
+  abv: string | null;
+  age: string | null;
+  cask: string | null;
+  volume: string | null;
+  description: string | null;
+  regionId: number | null;
+  korRegion: string | null;
+  engRegion: string | null;
+  distilleryId: number | null;
+  korDistillery: string | null;
+  engDistillery: string | null;
+  tastingTags: Array<{ id: number; korName: string | null; engName: string | null }>;
+};
+
+export type McpWhiskySearchResult = {
+  items: McpWhiskySummary[];
+  page: number;
+  size: number;
+  totalElements: number | null;
+  hasNext: boolean | null;
+};
+
+/**
+ * Outbound client: MCP process -> Admin backend only.
+ * Allowlist is enforced by calling fixed path builders (no free-form URL proxy).
+ */
+export class AdminBackendClient {
+  constructor(private readonly config: AppConfig) {}
+
+  async exchangeAgentKey(agentKey: string): Promise<TokenItem> {
+    assertAgentKeyShape(agentKey);
+    const body = await this.requestJson<GlobalResponseEnvelope<TokenItem>>(
+      "POST",
+      "/auth/agent",
+      { agentKey },
+      undefined,
+    );
+    const token = body.data;
+    if (!token?.accessToken) {
+      throw new Error("Agent login response missing accessToken");
+    }
+    return token;
+  }
+
+  async searchWhiskies(
+    accessToken: string,
+    params: { keyword?: string; page?: number; size?: number; regionId?: number },
+  ): Promise<McpWhiskySearchResult> {
+    const query = new URLSearchParams();
+    if (params.keyword) query.set("keyword", params.keyword);
+    if (params.regionId != null) query.set("regionId", String(params.regionId));
+    query.set("page", String(params.page ?? 0));
+    query.set("size", String(Math.min(params.size ?? 20, 50)));
+
+    const body = await this.requestJson<GlobalResponseEnvelope<McpWhiskySearchResult>>(
+      "GET",
+      `/mcp/whiskies?${query.toString()}`,
+      undefined,
+      accessToken,
+    );
+    if (!body.data) {
+      throw new Error("MCP whisky search returned empty data");
+    }
+    return body.data;
+  }
+
+  async getWhisky(accessToken: string, alcoholId: number): Promise<McpWhiskyDetail> {
+    const body = await this.requestJson<GlobalResponseEnvelope<McpWhiskyDetail>>(
+      "GET",
+      `/mcp/whiskies/${alcoholId}`,
+      undefined,
+      accessToken,
+    );
+    if (!body.data) {
+      throw new Error("MCP whisky detail returned empty data");
+    }
+    return body.data;
+  }
+
+  private async requestJson<T>(
+    method: string,
+    path: string,
+    jsonBody: unknown | undefined,
+    accessToken: string | undefined,
+  ): Promise<T> {
+    // Path must stay under fixed allowlist prefixes.
+    if (!path.startsWith("/auth/agent") && !path.startsWith("/mcp/")) {
+      throw new Error(`Outbound path not allowlisted: ${path}`);
+    }
+
+    const url = `${this.config.adminApiBaseUrl}${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.adminApiTimeoutMs);
+
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (jsonBody !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+    if (accessToken) {
+      headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    const started = Date.now();
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: jsonBody === undefined ? undefined : JSON.stringify(jsonBody),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      const durationMs = Date.now() - started;
+      logInfo("admin_backend_call", {
+        method,
+        path: path.split("?")[0],
+        status: response.status,
+        durationMs,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Admin API ${method} ${path.split("?")[0]} failed: ${response.status} ${redactSecrets(text)}`,
+        );
+      }
+      if (!text) {
+        return {} as T;
+      }
+      return JSON.parse(text) as T;
+    } catch (err) {
+      logError("admin_backend_call_failed", err);
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/mcp/src/backend/adminClient.ts
+++ b/mcp/src/backend/adminClient.ts
@@ -1,5 +1,6 @@
 import type { AppConfig } from "../config.js";
 import { assertAgentKeyShape } from "../auth/agentKey.js";
+import { assertOutboundAllowed } from "../policy/allowlist.js";
 import { logError, logInfo, redactSecrets } from "../logging/redact.js";
 
 export type TokenItem = {
@@ -14,7 +15,6 @@ type GlobalResponseEnvelope<T> = {
   meta?: Record<string, unknown>;
 };
 
-/** Existing Admin alcohol list item fields (subset). */
 type AdminAlcoholItem = {
   alcoholId: number;
   korName?: string | null;
@@ -77,31 +77,40 @@ export type McpWhiskySearchResult = {
   hasNext: boolean | null;
 };
 
+export type RequestContext = {
+  correlationId?: string;
+};
+
 /**
- * Outbound client: MCP process -> existing Admin API only.
- * No dedicated /mcp/* backend endpoints.
+ * Outbound client: MCP → existing Admin API only (P5 isolation).
  */
 export class AdminBackendClient {
   constructor(private readonly config: AppConfig) {}
 
-  async exchangeAgentKey(agentKey: string): Promise<TokenItem> {
+  async exchangeAgentKey(
+    agentKey: string,
+    ctx: RequestContext = {},
+  ): Promise<TokenItem> {
     assertAgentKeyShape(agentKey);
     const body = await this.requestJson<GlobalResponseEnvelope<TokenItem>>(
       "POST",
       "/auth/agent",
       { agentKey },
       undefined,
+      ctx,
     );
     const token = body.data;
     if (!token?.accessToken) {
       throw new Error("Agent login response missing accessToken");
     }
-    return token;
+    // Never surface refreshToken to tool layer.
+    return { accessToken: token.accessToken };
   }
 
   async searchWhiskies(
     accessToken: string,
     params: { keyword?: string; page?: number; size?: number; regionId?: number },
+    ctx: RequestContext = {},
   ): Promise<McpWhiskySearchResult> {
     const page = params.page ?? 0;
     const size = Math.min(params.size ?? 20, 50);
@@ -111,20 +120,19 @@ export class AdminBackendClient {
     query.set("page", String(page));
     query.set("size", String(size));
 
-    // Existing Admin UI contract: GET /alcohols (fromPage → data list + meta)
     const body = await this.requestJson<GlobalResponseEnvelope<AdminAlcoholItem[]>>(
       "GET",
       `/alcohols?${query.toString()}`,
       undefined,
       accessToken,
+      ctx,
     );
 
     const rows = Array.isArray(body.data) ? body.data : [];
     const meta = body.meta ?? {};
     const totalElements =
       typeof meta.totalElements === "number" ? meta.totalElements : null;
-    const hasNext =
-      typeof meta.hasNext === "boolean" ? meta.hasNext : null;
+    const hasNext = typeof meta.hasNext === "boolean" ? meta.hasNext : null;
 
     return {
       items: rows.map((row) => ({
@@ -142,12 +150,17 @@ export class AdminBackendClient {
     };
   }
 
-  async getWhisky(accessToken: string, alcoholId: number): Promise<McpWhiskyDetail> {
+  async getWhisky(
+    accessToken: string,
+    alcoholId: number,
+    ctx: RequestContext = {},
+  ): Promise<McpWhiskyDetail> {
     const body = await this.requestJson<GlobalResponseEnvelope<AdminAlcoholDetail>>(
       "GET",
       `/alcohols/${alcoholId}`,
       undefined,
       accessToken,
+      ctx,
     );
     const d = body.data;
     if (!d) {
@@ -164,7 +177,7 @@ export class AdminBackendClient {
       age: d.age ?? null,
       cask: d.cask ?? null,
       volume: d.volume ?? null,
-      description: d.description ?? null,
+      description: truncate(d.description ?? null, this.config.maxDescriptionChars),
       regionId: d.regionId ?? null,
       korRegion: d.korRegion ?? null,
       engRegion: d.engRegion ?? null,
@@ -184,17 +197,9 @@ export class AdminBackendClient {
     path: string,
     jsonBody: unknown | undefined,
     accessToken: string | undefined,
+    ctx: RequestContext,
   ): Promise<T> {
-    // Allowlist: agent login + existing alcohol read APIs only.
-    const pathOnly = path.split("?")[0] ?? path;
-    const allowed =
-      pathOnly === "/auth/agent" ||
-      pathOnly === "/alcohols" ||
-      /^\/alcohols\/\d+$/.test(pathOnly);
-    if (!allowed) {
-      throw new Error(`Outbound path not allowlisted: ${pathOnly}`);
-    }
-
+    const pathOnly = assertOutboundAllowed(method, path);
     const url = `${this.config.adminApiBaseUrl}${path}`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.config.adminApiTimeoutMs);
@@ -202,6 +207,9 @@ export class AdminBackendClient {
     const headers: Record<string, string> = {
       Accept: "application/json",
     };
+    if (ctx.correlationId) {
+      headers["x-correlation-id"] = ctx.correlationId;
+    }
     if (jsonBody !== undefined) {
       headers["Content-Type"] = "application/json";
     }
@@ -224,6 +232,7 @@ export class AdminBackendClient {
         path: pathOnly,
         status: response.status,
         durationMs,
+        correlationId: ctx.correlationId,
       });
 
       if (!response.ok) {
@@ -242,4 +251,10 @@ export class AdminBackendClient {
       clearTimeout(timer);
     }
   }
+}
+
+function truncate(value: string | null, max: number): string | null {
+  if (value == null) return null;
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}…`;
 }

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -2,9 +2,13 @@ export type AppConfig = {
   port: number;
   mcpPath: string;
   logLevel: string;
+  nodeEnv: string;
   adminApiBaseUrl: string;
   adminApiTimeoutMs: number;
+  /** Local/dev smoke only. Forbidden in production. */
   defaultAgentKey: string | undefined;
+  /** Truncate long free-text fields returned to agents. */
+  maxDescriptionChars: number;
 };
 
 function requireEnv(name: string, fallback?: string): string {
@@ -16,15 +20,26 @@ function requireEnv(name: string, fallback?: string): string {
 }
 
 export function loadConfig(): AppConfig {
+  const nodeEnv = process.env.NODE_ENV ?? "development";
+  const defaultAgentKey = process.env.BOTTLENOTE_AGENT_KEY;
+
+  if (nodeEnv === "production" && defaultAgentKey) {
+    throw new Error(
+      "BOTTLENOTE_AGENT_KEY must not be set in production (clients must send Authorization header)",
+    );
+  }
+
   return {
     port: Number(process.env.PORT ?? "3100"),
     mcpPath: process.env.MCP_PATH ?? "/mcp",
     logLevel: process.env.LOG_LEVEL ?? "info",
+    nodeEnv,
     adminApiBaseUrl: requireEnv(
       "ADMIN_API_BASE_URL",
       "http://localhost:8080/admin/api/v1",
     ).replace(/\/$/, ""),
     adminApiTimeoutMs: Number(process.env.ADMIN_API_TIMEOUT_MS ?? "15000"),
-    defaultAgentKey: process.env.BOTTLENOTE_AGENT_KEY,
+    defaultAgentKey,
+    maxDescriptionChars: Number(process.env.MAX_DESCRIPTION_CHARS ?? "800"),
   };
 }

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -1,0 +1,30 @@
+export type AppConfig = {
+  port: number;
+  mcpPath: string;
+  logLevel: string;
+  adminApiBaseUrl: string;
+  adminApiTimeoutMs: number;
+  defaultAgentKey: string | undefined;
+};
+
+function requireEnv(name: string, fallback?: string): string {
+  const value = process.env[name] ?? fallback;
+  if (!value) {
+    throw new Error(`Missing required env: ${name}`);
+  }
+  return value;
+}
+
+export function loadConfig(): AppConfig {
+  return {
+    port: Number(process.env.PORT ?? "3100"),
+    mcpPath: process.env.MCP_PATH ?? "/mcp",
+    logLevel: process.env.LOG_LEVEL ?? "info",
+    adminApiBaseUrl: requireEnv(
+      "ADMIN_API_BASE_URL",
+      "http://localhost:8080/admin/api/v1",
+    ).replace(/\/$/, ""),
+    adminApiTimeoutMs: Number(process.env.ADMIN_API_TIMEOUT_MS ?? "15000"),
+    defaultAgentKey: process.env.BOTTLENOTE_AGENT_KEY,
+  };
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -7,7 +7,10 @@ import { createMcpServer } from "./server.js";
 import {
   agentKeyFingerprint,
   extractAgentKey,
+  rejectionMessage,
+  validateAgentKey,
 } from "./auth/agentKey.js";
+import { MCP_HTTP_METHODS } from "./policy/allowlist.js";
 import { logError, logInfo, redactSecrets } from "./logging/redact.js";
 
 async function main(): Promise<void> {
@@ -22,37 +25,48 @@ async function main(): Promise<void> {
     res.status(200).json({ status: "ok", service: "mcp" });
   });
 
+  // Process is ready to accept traffic (no sticky session / no warm Admin dependency).
   app.get("/readyz", (_req, res) => {
-    res.status(200).json({ status: "ready", service: "mcp" });
+    res.status(200).json({ status: "ready", service: "mcp", nodeEnv: config.nodeEnv });
   });
 
   /**
-   * Stateless Streamable HTTP:
-   * - no sticky session requirement across pods
-   * - Agent Key from Authorization: Bearer bn_agent_*
-   * - Admin JWT never returned to client
+   * Stateless Streamable HTTP (P1):
+   * - no sticky session across pods
+   * - Agent Key only (P2); Admin JWT never returned
    */
   app.all(config.mcpPath, async (req, res) => {
     const correlationId = (req.header("x-correlation-id") ?? randomUUID()).toString();
     res.setHeader("x-correlation-id", correlationId);
 
-    const agentKey = extractAgentKey(
-      req.header("authorization") ?? undefined,
-      config.defaultAgentKey,
-    );
-    if (!agentKey) {
-      res.status(401).json({
-        error: "unauthorized",
-        message: "Missing Agent Key (Authorization: Bearer bn_agent_*)",
+    if (!MCP_HTTP_METHODS.has(req.method.toUpperCase())) {
+      res.status(405).json({
+        error: "method_not_allowed",
+        message: `Method ${req.method} not allowed on MCP endpoint`,
         correlationId,
       });
       return;
     }
 
+    const rawKey = extractAgentKey(
+      req.header("authorization") ?? undefined,
+      config.defaultAgentKey,
+    );
+    const validated = validateAgentKey(rawKey);
+    if (!validated.ok) {
+      res.status(401).json({
+        error: "unauthorized",
+        message: rejectionMessage(validated.reason),
+        correlationId,
+      });
+      return;
+    }
+    const agentKey = validated.key;
+
     const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined, // stateless
+      sessionIdGenerator: undefined,
     });
-    const server = createMcpServer(client, agentKey);
+    const server = createMcpServer(client, agentKey, { correlationId });
 
     try {
       await server.connect(transport);
@@ -76,23 +90,35 @@ async function main(): Promise<void> {
       try {
         await transport.close();
       } catch {
-        // ignore close races
+        // ignore
       }
       try {
         await server.close();
       } catch {
-        // ignore close races
+        // ignore
       }
     }
   });
 
-  app.listen(config.port, () => {
+  const server = app.listen(config.port, () => {
     logInfo("mcp listening", {
       port: config.port,
       mcpPath: config.mcpPath,
+      // host only — no secrets
       adminApiBaseUrl: config.adminApiBaseUrl,
+      nodeEnv: config.nodeEnv,
     });
   });
+
+  const shutdown = (signal: string) => {
+    logInfo("shutdown", { signal });
+    server.close(() => {
+      process.exit(0);
+    });
+    setTimeout(() => process.exit(1), 10_000).unref();
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
 }
 
 main().catch((err) => {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,101 @@
+import express from "express";
+import { randomUUID } from "node:crypto";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { loadConfig } from "./config.js";
+import { AdminBackendClient } from "./backend/adminClient.js";
+import { createMcpServer } from "./server.js";
+import {
+  agentKeyFingerprint,
+  extractAgentKey,
+} from "./auth/agentKey.js";
+import { logError, logInfo, redactSecrets } from "./logging/redact.js";
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const client = new AdminBackendClient(config);
+  const app = express();
+
+  app.disable("x-powered-by");
+  app.use(express.json({ limit: "1mb" }));
+
+  app.get("/healthz", (_req, res) => {
+    res.status(200).json({ status: "ok", service: "mcp" });
+  });
+
+  app.get("/readyz", (_req, res) => {
+    res.status(200).json({ status: "ready", service: "mcp" });
+  });
+
+  /**
+   * Stateless Streamable HTTP:
+   * - no sticky session requirement across pods
+   * - Agent Key from Authorization: Bearer bn_agent_*
+   * - Admin JWT never returned to client
+   */
+  app.all(config.mcpPath, async (req, res) => {
+    const correlationId = (req.header("x-correlation-id") ?? randomUUID()).toString();
+    res.setHeader("x-correlation-id", correlationId);
+
+    const agentKey = extractAgentKey(
+      req.header("authorization") ?? undefined,
+      config.defaultAgentKey,
+    );
+    if (!agentKey) {
+      res.status(401).json({
+        error: "unauthorized",
+        message: "Missing Agent Key (Authorization: Bearer bn_agent_*)",
+        correlationId,
+      });
+      return;
+    }
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined, // stateless
+    });
+    const server = createMcpServer(client, agentKey);
+
+    try {
+      await server.connect(transport);
+      logInfo("mcp_request", {
+        correlationId,
+        method: req.method,
+        path: config.mcpPath,
+        agentFp: agentKeyFingerprint(agentKey),
+      });
+      await transport.handleRequest(req, res, req.body);
+    } catch (err) {
+      logError("mcp_request_failed", { correlationId, err: redactSecrets(err) });
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: "internal_error",
+          message: "MCP request failed",
+          correlationId,
+        });
+      }
+    } finally {
+      try {
+        await transport.close();
+      } catch {
+        // ignore close races
+      }
+      try {
+        await server.close();
+      } catch {
+        // ignore close races
+      }
+    }
+  });
+
+  app.listen(config.port, () => {
+    logInfo("mcp listening", {
+      port: config.port,
+      mcpPath: config.mcpPath,
+      adminApiBaseUrl: config.adminApiBaseUrl,
+    });
+  });
+}
+
+main().catch((err) => {
+  logError("fatal", err);
+  process.exit(1);
+});

--- a/mcp/src/logging/redact.ts
+++ b/mcp/src/logging/redact.ts
@@ -1,0 +1,27 @@
+const AGENT_KEY_PATTERN = /bn_agent_[A-Za-z0-9_-]{20,}/g;
+const JWT_PATTERN = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+const BEARER_PATTERN = /(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi;
+
+/** Scrub secrets before any log/error surface leaves the process. */
+export function redactSecrets(input: unknown): string {
+  let text: string;
+  try {
+    text = typeof input === "string" ? input : JSON.stringify(input);
+  } catch {
+    text = String(input);
+  }
+  return text
+    .replace(AGENT_KEY_PATTERN, "bn_agent_[REDACTED]")
+    .replace(JWT_PATTERN, "[JWT_REDACTED]")
+    .replace(BEARER_PATTERN, "$1[REDACTED]");
+}
+
+export function logInfo(message: string, meta?: Record<string, unknown>): void {
+  const payload = meta ? ` ${redactSecrets(meta)}` : "";
+  console.log(`[info] ${message}${payload}`);
+}
+
+export function logError(message: string, err?: unknown): void {
+  const detail = err === undefined ? "" : ` ${redactSecrets(err)}`;
+  console.error(`[error] ${message}${detail}`);
+}

--- a/mcp/src/policy/allowlist.ts
+++ b/mcp/src/policy/allowlist.ts
@@ -1,0 +1,39 @@
+/** Allowed Admin API surface for this MCP gateway (isolation boundary). */
+export type AllowedOutbound = {
+  method: "GET" | "POST";
+  pathPattern: RegExp;
+  description: string;
+};
+
+export const OUTBOUND_ALLOWLIST: AllowedOutbound[] = [
+  {
+    method: "POST",
+    pathPattern: /^\/auth\/agent$/,
+    description: "Agent Key → Admin JWT exchange",
+  },
+  {
+    method: "GET",
+    pathPattern: /^\/alcohols$/,
+    description: "Whisky search/list",
+  },
+  {
+    method: "GET",
+    pathPattern: /^\/alcohols\/\d+$/,
+    description: "Whisky detail",
+  },
+];
+
+export function assertOutboundAllowed(method: string, pathWithQuery: string): string {
+  const pathOnly = pathWithQuery.split("?")[0] ?? pathWithQuery;
+  const upper = method.toUpperCase();
+  const ok = OUTBOUND_ALLOWLIST.some(
+    (rule) => rule.method === upper && rule.pathPattern.test(pathOnly),
+  );
+  if (!ok) {
+    throw new Error(`Outbound not allowlisted: ${upper} ${pathOnly}`);
+  }
+  return pathOnly;
+}
+
+/** MCP transport methods we accept on /mcp (Streamable HTTP). */
+export const MCP_HTTP_METHODS = new Set(["GET", "POST", "DELETE"]);

--- a/mcp/src/policy/instructions.ts
+++ b/mcp/src/policy/instructions.ts
@@ -1,0 +1,17 @@
+/**
+ * Server-level instructions exposed to MCP clients (P1 + P4).
+ * Keep short: agents load this every session.
+ */
+export const MCP_SERVER_INSTRUCTIONS = `
+Bottle Note Admin MCP (read-only gateway).
+
+Auth: send Authorization: Bearer bn_agent_*. Never send Admin JWT.
+This server exchanges the key internally; tokens are never returned to you.
+
+Tools (v0.1):
+- bottlenote_whisky_search: paginated whisky search (size max 50).
+- bottlenote_whisky_get: one whisky by alcoholId.
+
+Do NOT attempt delete, bulk edit, free-form HTTP, or external web search via this server.
+Prefer search then get. Use alcoholId from search results for detail.
+`.trim();

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,17 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AdminBackendClient } from "./backend/adminClient.js";
+import { registerWhiskyTools, RequestAuthCache } from "./tools/whisky.js";
+
+export function createMcpServer(
+  client: AdminBackendClient,
+  agentKey: string,
+): McpServer {
+  const server = new McpServer({
+    name: "mcp",
+    version: "0.1.0",
+  });
+
+  const auth = new RequestAuthCache(client, agentKey);
+  registerWhiskyTools(server, client, auth);
+  return server;
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,17 +1,27 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { AdminBackendClient } from "./backend/adminClient.js";
+import type { AdminBackendClient, RequestContext } from "./backend/adminClient.js";
+import { MCP_SERVER_INSTRUCTIONS } from "./policy/instructions.js";
 import { registerWhiskyTools, RequestAuthCache } from "./tools/whisky.js";
 
 export function createMcpServer(
   client: AdminBackendClient,
   agentKey: string,
+  ctx: RequestContext = {},
 ): McpServer {
-  const server = new McpServer({
-    name: "mcp",
-    version: "0.1.0",
-  });
+  const server = new McpServer(
+    {
+      name: "mcp",
+      version: "0.1.0",
+    },
+    {
+      instructions: MCP_SERVER_INSTRUCTIONS,
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
 
-  const auth = new RequestAuthCache(client, agentKey);
-  registerWhiskyTools(server, client, auth);
+  const auth = new RequestAuthCache(client, agentKey, ctx);
+  registerWhiskyTools(server, client, auth, ctx);
   return server;
 }

--- a/mcp/src/tools/whisky.ts
+++ b/mcp/src/tools/whisky.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AdminBackendClient } from "../backend/adminClient.js";
+import { agentKeyFingerprint, assertAgentKeyShape } from "../auth/agentKey.js";
+import { logInfo } from "../logging/redact.js";
+
+type SessionAuth = {
+  agentKey: string;
+  accessToken: string;
+  expiresAtMs: number;
+};
+
+/**
+ * Per-request auth cache only. Multi-pod safe: no process-global agent state.
+ * Access token is never returned to MCP clients.
+ */
+export class RequestAuthCache {
+  private entry: SessionAuth | undefined;
+
+  constructor(
+    private readonly client: AdminBackendClient,
+    private readonly agentKey: string,
+  ) {
+    assertAgentKeyShape(agentKey);
+  }
+
+  async getAccessToken(): Promise<string> {
+    const now = Date.now();
+    if (this.entry && this.entry.expiresAtMs > now + 5_000) {
+      return this.entry.accessToken;
+    }
+    const token = await this.client.exchangeAgentKey(this.agentKey);
+    this.entry = {
+      agentKey: this.agentKey,
+      accessToken: token.accessToken,
+      // Prefer short in-process TTL; backend access is typically 24h but we re-exchange often.
+      expiresAtMs: now + 10 * 60_000,
+    };
+    logInfo("agent_token_exchanged", { agentFp: agentKeyFingerprint(this.agentKey) });
+    return this.entry.accessToken;
+  }
+}
+
+export function registerWhiskyTools(
+  server: McpServer,
+  client: AdminBackendClient,
+  auth: RequestAuthCache,
+): void {
+  server.registerTool(
+    "bottlenote_whisky_search",
+    {
+      title: "Search whiskies",
+      description:
+        "Search Bottle Note admin whiskies with compact fields for agent context. size max 50.",
+      inputSchema: {
+        keyword: z.string().min(1).max(100).optional(),
+        regionId: z.number().int().positive().optional(),
+        page: z.number().int().min(0).default(0),
+        size: z.number().int().min(1).max(50).default(20),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ keyword, regionId, page, size }) => {
+      const accessToken = await auth.getAccessToken();
+      const result = await client.searchWhiskies(accessToken, {
+        keyword,
+        regionId,
+        page,
+        size,
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "bottlenote_whisky_get",
+    {
+      title: "Get whisky detail",
+      description: "Fetch one whisky by alcoholId with MCP-optimized admin fields.",
+      inputSchema: {
+        alcoholId: z.number().int().positive(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ alcoholId }) => {
+      const accessToken = await auth.getAccessToken();
+      const detail = await client.getWhisky(accessToken, alcoholId);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(detail),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/mcp/src/tools/whisky.ts
+++ b/mcp/src/tools/whisky.ts
@@ -1,18 +1,17 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { AdminBackendClient } from "../backend/adminClient.js";
+import type { AdminBackendClient, RequestContext } from "../backend/adminClient.js";
 import { agentKeyFingerprint, assertAgentKeyShape } from "../auth/agentKey.js";
-import { logInfo } from "../logging/redact.js";
+import { logInfo, redactSecrets } from "../logging/redact.js";
 
 type SessionAuth = {
-  agentKey: string;
   accessToken: string;
   expiresAtMs: number;
 };
 
 /**
  * Per-request auth cache only. Multi-pod safe: no process-global agent state.
- * Access token is never returned to MCP clients.
+ * Access token is never returned to MCP clients (P2).
  */
 export class RequestAuthCache {
   private entry: SessionAuth | undefined;
@@ -20,6 +19,7 @@ export class RequestAuthCache {
   constructor(
     private readonly client: AdminBackendClient,
     private readonly agentKey: string,
+    private readonly ctx: RequestContext,
   ) {
     assertAgentKeyShape(agentKey);
   }
@@ -29,29 +29,47 @@ export class RequestAuthCache {
     if (this.entry && this.entry.expiresAtMs > now + 5_000) {
       return this.entry.accessToken;
     }
-    const token = await this.client.exchangeAgentKey(this.agentKey);
+    const token = await this.client.exchangeAgentKey(this.agentKey, this.ctx);
     this.entry = {
-      agentKey: this.agentKey,
       accessToken: token.accessToken,
-      // Prefer short in-process TTL; backend access is typically 24h but we re-exchange often.
       expiresAtMs: now + 10 * 60_000,
     };
-    logInfo("agent_token_exchanged", { agentFp: agentKeyFingerprint(this.agentKey) });
+    logInfo("agent_token_exchanged", {
+      agentFp: agentKeyFingerprint(this.agentKey),
+      correlationId: this.ctx.correlationId,
+    });
     return this.entry.accessToken;
   }
+}
+
+function toolError(err: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: redactSecrets(err instanceof Error ? err.message : String(err)),
+      },
+    ],
+  };
 }
 
 export function registerWhiskyTools(
   server: McpServer,
   client: AdminBackendClient,
   auth: RequestAuthCache,
+  ctx: RequestContext,
 ): void {
   server.registerTool(
     "bottlenote_whisky_search",
     {
       title: "Search whiskies",
       description:
-        "Search Bottle Note admin whiskies with compact fields for agent context. size max 50.",
+        "Search Bottle Note admin whiskies. Returns compact fields for agent context. " +
+        "size default 20, max 50. Use keyword and/or regionId. Prefer this before get.",
       inputSchema: {
         keyword: z.string().min(1).max(100).optional(),
         regionId: z.number().int().positive().optional(),
@@ -66,21 +84,19 @@ export function registerWhiskyTools(
       },
     },
     async ({ keyword, regionId, page, size }) => {
-      const accessToken = await auth.getAccessToken();
-      const result = await client.searchWhiskies(accessToken, {
-        keyword,
-        regionId,
-        page,
-        size,
-      });
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(result),
-          },
-        ],
-      };
+      try {
+        const accessToken = await auth.getAccessToken();
+        const result = await client.searchWhiskies(
+          accessToken,
+          { keyword, regionId, page, size },
+          ctx,
+        );
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+        };
+      } catch (err) {
+        return toolError(err);
+      }
     },
   );
 
@@ -88,7 +104,9 @@ export function registerWhiskyTools(
     "bottlenote_whisky_get",
     {
       title: "Get whisky detail",
-      description: "Fetch one whisky by alcoholId with MCP-optimized admin fields.",
+      description:
+        "Fetch one whisky by alcoholId. Long description may be truncated. " +
+        "Use alcoholId from bottlenote_whisky_search.",
       inputSchema: {
         alcoholId: z.number().int().positive(),
       },
@@ -100,16 +118,15 @@ export function registerWhiskyTools(
       },
     },
     async ({ alcoholId }) => {
-      const accessToken = await auth.getAccessToken();
-      const detail = await client.getWhisky(accessToken, alcoholId);
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(detail),
-          },
-        ],
-      };
+      try {
+        const accessToken = await auth.getAccessToken();
+        const detail = await client.getWhisky(accessToken, alcoholId, ctx);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(detail) }],
+        };
+      } catch (err) {
+        return toolError(err);
+      }
     },
   );
 }

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- workspace 루트에 격리형 Admin MCP 게이트웨이 `mcp/` 추가
- 구조: **클라이언트 → MCP(Streamable HTTP) → 기존 admin-api** (전용 `/mcp/*` 백엔드 API 없음)
- 패키지명 `mcp` (`bottlenote-` 접두사 없음)
- 백엔드 전용 MCP API PR(bottle-note-api-server#699)은 **폐기·클로즈**. MCP가 기존 Admin 계약을 호출

```
Admin / Agent client (Claude, Codex, Cursor)
        |  Streamable HTTP  /mcp
        |  Authorization: Bearer bn_agent_*
        v
 mcp/  (이 PR)
        |  allowlist only
        |  Agent Key → 내부 Admin JWT (클라이언트 미노출)
        v
 bottlenote-admin-api
   POST /admin/api/v1/auth/agent
   GET  /admin/api/v1/alcohols
   GET  /admin/api/v1/alcohols/{id}
```

## Changes
- `mcp/`: Node 22 + TypeScript MCP 서버 스캐폴드
- 툴 v0.1: `bottlenote_whisky_search`, `bottlenote_whisky_get` (기존 `/alcohols` 매핑)
- multi-arch Dockerfile (`linux/amd64`, `linux/arm64`)
- root/mcp `.gitignore` 강화 (node_modules, .env, sops, kubeconfig, credentials 제외)
- private `environment-variables` 서브모듈은 **포함하지 않음**
- 페르소나 교차 규범: `mcp/docs/PRINCIPLES.md`
- 보안 보강: JWT 형태 Bearer 거부, prod에서 default Agent Key 금지, 툴 `isError`, description truncate, correlation 전파, graceful shutdown, server `instructions`

## Authentication (현재 v0.1)

| 항목 | 내용 |
|------|------|
| 방식 | 원격 MCP + **Agent Key Bearer** (OAuth 2.1 전 단계) |
| 클라이언트 제시 | `Authorization: Bearer bn_agent_*` 만 |
| 서버 내부 | `POST /auth/agent` 로 Admin JWT 교환 후 API 호출 |
| 금지 | Admin/User JWT 클라이언트 전달(token passthrough), 키/JWT 로그·툴 결과 노출 |
| 기획자 온보딩 | **키 1개 + MCP URL + 클라이언트 설정 방법** (Admin 계정/JWT 불필요) |

### 클라이언트 설정 예

```json
{
  "mcpServers": {
    "bottlenote-admin": {
      "url": "https://mcp.bottlenote.com/mcp",
      "headers": {
        "Authorization": "Bearer bn_agent_REPLACE"
      }
    }
  }
}
```

### 이후 후보 (미구현)
- OAuth 2.1 Resource Server + Protected Resource Metadata (스펙 정석 원격 인증)
- 토큰 검증·scope는 **MCP 서버**, 발급은 별도 AS/IdP

## 백엔드 방화벽 / 개발 서버 방향 (합의 메모)

완전 잠금은 **네트워크 격리 + 호출자 신원**이 CORS보다 우선이다.

| 환경 | 권장 |
|------|------|
| **dev (공유 개발)** | Admin API **공개 유지**. FE는 포트포워드/k9s 없이 dev URL 직접 호출. MCP dev도 동일 Admin dev base URL |
| **local** | FE → dev API 또는 로컬 API. k9s 강요하지 않음 |
| **prod (목표)** | Admin API 외부 최소화(ClusterIP/내부 DNS). **공개는 FE(BFF)·MCP**. 내부 토큰/mTLS/NetworkPolicy 이중화 |

- FE가 pure SPA + 브라우저 직접 Admin 호출이면 prod에서 API를 완전 숨기기 어렵다 → 잠글 때는 **BFF/SSR** 또는 VPN/Zero Trust 필요
- 앱 레벨 `INTERNAL_TOKEN` 강제는 **prod(또는 staging) 플래그**로만 켜고, dev에서는 끄는 것을 권장

## Security / gitignore
- 실키·JWT·node_modules·dist·sops·kubeconfig 미포함 확인 후 푸시
- `.env.example` 만 포함 (placeholder). `BOTTLENOTE_AGENT_KEY` 는 local smoke 전용, **production 기동 시 설정 시 실패**
- 아웃바운드 allowlist: `POST /auth/agent`, `GET /alcohols`, `GET /alcohols/{id}` (`src/policy/allowlist.ts`)
- NEVER: 삭제/bulk/무페이징 list, free-form HTTP 프록시, 외부 웹검색 툴

## Related
- bottle-note/workspace#370
- #340 Agent Key 토큰 교환 (인증 기반)
- #341 감사 actor 모델 (후속)
- backend 전용 MCP API 시도는 폐기: bottle-note/bottle-note-api-server#699 (closed)

## Test plan
- [ ] PR 파일 목록에 `node_modules` / `.env` / sops / 실제 키 없음
- [ ] `cd mcp && npm install && npm run typecheck`
- [ ] (optional) admin-api 연동 후 whisky search/get 스모크
- [ ] JWT 형태 Bearer → 401, 누락 키 → 401
- [ ] `NODE_ENV=production` + `BOTTLENOTE_AGENT_KEY` 설정 시 기동 실패